### PR TITLE
Update ForgeFlower version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     compile 'com.nothome:javaxdelta:2.0.1' // GDIFF implementation for BinPatches
     compile 'com.google.code.gson:gson:2.2.4' // Used instead of Argo for buuilding changelog.
     compile 'com.github.tony19:named-regexp:0.2.3' // 1.7 Named regexp features
-    compile 'net.minecraftforge:forgeflower:1.5.380.22' // Fernflower Forge edition
+    compile 'net.minecraftforge:forgeflower:1.5.380.26' // Fernflower Forge edition
 
     shade 'net.md-5:SpecialSource:1.8.3' // deobf and reobf
 


### PR DESCRIPTION
Latest MCPConfigs are using a newer ForgeFlower version which is causing hunk target errors.